### PR TITLE
retain datacenter/cluster info per host

### DIFF
--- a/tasks/patch/task.sh
+++ b/tasks/patch/task.sh
@@ -5,9 +5,9 @@ echo "Finding all hosts..."
 
 if [ -z $CLUSTER_NAME ]
 then
-  govc find . -type h | sed 's/.*\///' > hosts.txt
+  govc find . -type h > hosts.txt
 else
-  govc find $(govc find . -type c -name $CLUSTER_NAME) -type h | sed 's/.*\///' > hosts.txt
+  govc find $(govc find . -type c -name $CLUSTER_NAME) -type h > hosts.txt
 fi
 
 echo "Hosts to be patched are"


### PR DESCRIPTION
As written, task.sh strips the datacenter and cluster info from hosts.txt entries.

Our pipeline failed on line 20, when executing "govc host.info" with error

```
govc: please specify a datacenter
```

We found by leaving the datacenter/cluster info in hosts.txt this call succeeds.  It also allows us to support multiple datacenters in the vcenter.

```
○ → govc host.info -host=baker.smurf.cf-app.com
govc: please specify a datacenter

○ → govc host.info -host=/sixfive-dc/host/stormwind-2/baker.smurf.cf-app.com
Name:              baker.smurf.cf-app.com
  Path:            /sixfive-dc/host/stormwind-2/baker.smurf.cf-app.com
  Manufacturer:    VMware, Inc.
  Logical CPUs:    16 CPUs @ 2700MHz
  Processor type:  Intel(R) Xeon(R) CPU E5-2680 0 @ 2.70GHz
  CPU usage:       101 MHz (0.2%)
  Memory:          16383MB
  Memory usage:    1901 MB (11.6%)
  Boot time:       2018-01-25 01:29:59.804014 +0000 UTC
  State:           connected

○ → govc host.info -host=/nested-dc-folder/nested-dc/host/nested-dc-cluster/lucky.smurf.cf-app.com
Name:              lucky.smurf.cf-app.com
  Path:            /nested-dc-folder/nested-dc/host/nested-dc-cluster/lucky.smurf.cf-app.com
  Manufacturer:    VMware, Inc.
  Logical CPUs:    16 CPUs @ 2700MHz
  Processor type:  Intel(R) Xeon(R) CPU E5-2680 0 @ 2.70GHz
  CPU usage:       257 MHz (0.6%)
  Memory:          16383MB
  Memory usage:    1868 MB (11.4%)
  Boot time:       2018-02-02 00:46:11.091768 +0000 UTC
  State:           connected
```